### PR TITLE
Ajout du support des recherches des package dans /etc/apt/sources.list.d/*.list

### DIFF
--- a/nginxautoinstall.sh
+++ b/nginxautoinstall.sh
@@ -80,21 +80,21 @@ fi
 displaytitle "Install prerequisites"
 
 # Récupération GnuPG key pour DotDeb
-grep '^deb\ .*dotdeb' /etc/apt/sources.list > /dev/null
+grep -rq '^deb\ .*dotdeb' /etc/apt/sources.list.d/*.list /etc/apt/sources.list
 if [ $? -ne 0 ]
 then
   displayandexec "Install the DotDeb repository" "wget http://www.dotdeb.org/dotdeb.gpg ; cat dotdeb.gpg | apt-key add - ; rm -f dotdeb.gpg"
 fi
 
 # Ajout DotDeb package (http://www.dotdeb.org/)
-grep '^deb\ .*packages\.dotdeb' /etc/apt/sources.list > /dev/null
+grep -rq '^deb\ .*packages\.dotdeb' /etc/apt/sources.list.d/*.list /etc/apt/sources.list
 if [ $? -ne 0 ]
 then  
   echo -e "\n## DotDeb Package\ndeb http://packages.dotdeb.org stable all\ndeb-src http://packages.dotdeb.org stable all\n" >> /etc/apt/sources.list
 fi
 
 # Ajout DotDeb PHP 5.3 (http://www.dotdeb.org/)
-grep '^deb\ .*php53\.dotdeb' /etc/apt/sources.list > /dev/null
+grep -rq '^deb\ .*php53\.dotdeb' /etc/apt/sources.list.d/*.list /etc/apt/sources.list
 if [ $? -ne 0 ]
 then
   echo -e "\n## DotDeb PHP 5.3\ndeb http://php53.dotdeb.org stable all\ndeb-src http://php53.dotdeb.org stable all\n" >> /etc/apt/sources.list


### PR DESCRIPTION
J'ai ajouté le support des recherches des `packages` debian dans les fichiers  `/etc/apt/sources.list.d/*.list` tout en conservant le support des recherches dans :  `/etc/apt/sources.list`

De plus j'ai utilisé le paramètre -q (silencieux) à la commande `grep` pour le pas être obligé d'envoyer le résultat dans `/dev/null`
