### PR TITLE
[PHP] Removed php5-cgi, changed php5-xcache to php5-apc

### DIFF
--- a/nginxautoinstall.sh
+++ b/nginxautoinstall.sh
@@ -129,7 +129,7 @@ displayandexec "Update the repositories list" $APT_GET update
 
 # Pre-requis
 displayandexec "Install development tools" $APT_GET install build-essential libpcre3-dev libssl-dev zlib1g-dev
-displayandexec "Install PHP 5" $APT_GET install php5-cli php5-common php5-mysql php5-suhosin php5-fpm php5-cgi php-pear php5-xcache php5-gd php5-curl
+displayandexec "Install PHP 5" $APT_GET install php5-cli php5-common php5-mysql php5-suhosin php5-fpm php-pear php5-apc php5-gd php5-curl
 displayandexec "Install MemCached" $APT_GET install libcache-memcached-perl php5-memcache memcached
 
 displaytitle "Install NGinx version $NGINX_VERSION"


### PR DESCRIPTION
php5-cgi is useless because script use php fpm.
And apc is better than xcache.
