### PR TITLE
Correctif de sécurité ajouté dans le fichier default site

### DIFF
--- a/default-site
+++ b/default-site
@@ -10,6 +10,11 @@ server {
 
         # PHP scripts -> PHP-FPM server listening on 127.0.0.1:9000
         location ~ \.php$ {
+                 # The following line prevents malicious php code to be executed through some uploaded file (without php extension, like image)
+                 # This fix shoudn't work though, if nginx and php are not on the same server, other options exist (like unauthorizing php execution within upload folder)
+                 # More on this serious security concern in the "Pass Non-PHP Requests to PHP" section, there http://wiki.nginx.org/Pitfalls
+                 try_files $uri =404;
+
                  fastcgi_pass   127.0.0.1:9000;
                  fastcgi_index  index.php;
                  include fastcgi_params;


### PR DESCRIPTION
Bonjour,

Merci pour le script d'install de ngninx+php, très utile et pratique.

Je me permets de proposer une toute petite modif, mais à mon avis fort utile.

Les fichiers de configs par défauts de nginx pour php sont souvent l'objet d'une faille de sécurité (assez sérieuse), comme je l'ai découvert là:
https://nealpoole.com/blog/2011/04/setting-up-php-fastcgi-and-nginx-dont-trust-the-tutorials-check-your-configuration/

C'est le cas ici, d'où la modif. que j'espère utile.

Yves.
